### PR TITLE
Adjust syntaxes

### DIFF
--- a/src/CWTConstruction.jl
+++ b/src/CWTConstruction.jl
@@ -32,7 +32,7 @@ struct CWT{B,S,W <: ContWaveClass,N,isAn} <: ContWave{B,S}
 end
 
 # aliased = ((:Q,:s,:scalingFactor), (:β,:decreasing), (:p, :normalization))
-function processKeywordArgs(Q, β, p;kwargs...)
+function processKeywordArgs(Q, β, p; kwargs...)
     keysVarg = keys(kwargs)
     if :s in keysVarg
         Q = kwargs[:s]
@@ -86,7 +86,7 @@ end
 
 function calculateProperties(w::Morlet)
     σ = w.σ
-    fourierFactor = (4 * π) / (σ + sqrt(2 + σ.^2))
+    fourierFactor = (4 * π) / (σ + sqrt(2 + σ^2))
     coi = 1 / sqrt(2)
     α = -1
     σ = [w.σ, w.κσ, w.cσ]
@@ -95,7 +95,7 @@ end
 
 function calculateProperties(w::Dog)
     α = order(w)
-    fourierFactor = 2 * π * sqrt(2 ./ (2 * α + 1))
+    fourierFactor = 2 * π * sqrt(2 / (2 * α + 1))
     coi = 1 / sqrt(2)
     σ = [NaN]
     return fourierFactor, coi, α, σ, w

--- a/src/ContinuousWavelets.jl
+++ b/src/ContinuousWavelets.jl
@@ -1,4 +1,5 @@
 module ContinuousWavelets
+
 using Wavelets
 using Interpolations
 using AbstractFFTs
@@ -7,15 +8,14 @@ using LinearAlgebra
 using SpecialFunctions
 
 import Wavelets.wavelet
-import Wavelets.WT.name, Wavelets.WT.class,
-   Wavelets.WT.vanishingmoments
+import Wavelets.WT.name, Wavelets.WT.class, Wavelets.WT.vanishingmoments
 
 export ContWave, CWT, cwt, icwt
 
 # Boundaries
 export WaveletBoundary, PerBoundary, ZPBoundary, NullBoundary, SymBoundary,
     Periodic, DEFAULT_BOUNDARY, padded, NaivePer, SymBound
-# waveletTypes (note there are also export statements in the for loops of waveletTypes.jl)
+# wavelet types (note there are also export statements in the for loops of waveletTypes.jl)
 export Morlet, Paul, Dog, ContOrtho, Morse, name, vanishingmoments, ContOrtho
 export cHaar, cBeyl, cVaid, morl, morse
 # averaging types
@@ -105,10 +105,12 @@ const NaivePer = PerBoundary()
 const SymBound = SymBoundary()
 
 abstract type ContWaveClass end # equivalent to ContinuousWaveletClass in Wavelets.jl
+
 include("waveletTypes.jl")
 include("CWTConstruction.jl")
 include("utils.jl")
 include("sanityChecks.jl")
 include("createWavelets.jl")
 include("apply.jl")
+
 end

--- a/src/apply.jl
+++ b/src/apply.jl
@@ -22,14 +22,14 @@
   you will need to scale wave by δt^(1/2).
   The default assumption is that the sampling rate is 1kHz.
 
-  """
+"""
 function cwt(Y::AbstractArray{T,N}, cWav::CWT, daughters, fftPlans = 1) where {N, T}
     @assert typeof(N)<:Integer
     # vectors behave a bit strangely, so we reshape them
     if N==1
         Y= reshape(Y,(length(Y), 1))
     end
-    n1 = size(Y, 1);
+    n1 = size(Y, 1)
 
     _, nScales, _ = getNWavelets(n1, cWav)
     #construct time series to analyze, pad if necessary
@@ -50,7 +50,7 @@ function cwt(Y::AbstractArray{T,N}, cWav::CWT, daughters, fftPlans = 1) where {N
         OutType = T
     end
 
-    wave = zeros(OutType, size(x)..., nScales);  # result array;
+    wave = zeros(OutType, size(x)..., nScales)  # result array
     # faster if we put the example index on the outside loop through all scales
     # and compute transform
     if isAnalytic(cWav.waveType)
@@ -71,6 +71,7 @@ function cwt(Y::AbstractArray{T,N}, cWav::CWT, daughters, fftPlans = 1) where {N
 
     return wave
 end
+
 function ensureComplex(T)
     if T <: Real
         return Complex{T}
@@ -78,6 +79,7 @@ function ensureComplex(T)
         return T
     end
 end
+
 # there are 4 cases to deal with
 #       input Type | Real | Complex
 #       analytic?  |----------------
@@ -226,9 +228,11 @@ end
 
 
 """
-period,scale, coi = caveats(Y::AbstractArray{T}, c::CWT{W}; J1::S=NaN) where {T<:Real, S<:Real, W<:WaveletBoundary}
+    caveats(Y::AbstractArray{T}, c::CWT{W}; J1::S=NaN) where {T<:Real, S<:Real, W<:WaveletBoundary} -> period,scale, coi
 
-returns the period, the scales, and the cone of influence for the given wavelet transform. If you have sampling information, you will need to scale the vector scale appropriately by 1/δt, and the actual transform by δt^(1/2).
+Returns the period, the scales, and the cone of influence for the given wavelet transform.
+If you have sampling information, you will need to scale the vector scale appropriately by
+1/δt, and the actual transform by δt^(1/2).
 """
 function caveats(n1, c::CWT{W}; J1::Int64=-1, dt::S=1/1000, s0::V=NaN) where {S<:Real, W<:WaveletBoundary, V <: Real}
     # don't alter scaling with sampling information if it doesn't exists
@@ -252,10 +256,10 @@ function caveats(n1, c::CWT{W}; J1::Int64=-1, dt::S=1/1000, s0::V=NaN) where {S<
     coi = (fλ * dt / sqrt(2)).*coi
 
 
-    n1 = length(Y);
+    n1 = length(Y)
     # J1 is the total number of elements
     if isnan(J1) || (J1<0)
-        J1=floor(Int,(log2(n1))*c.Q);
+        J1=floor(Int,(log2(n1))*c.Q)
     end
     #....construct time series to analyze, pad if necessary
     if boundaryType(c) == ZPBoundary
@@ -270,6 +274,7 @@ function caveats(n1, c::CWT{W}; J1::Int64=-1, dt::S=1/1000, s0::V=NaN) where {S<
     coi = c.coi*scale  # COI [Sec.3g]
     return sj, freqs, period, scale, coi
 end
+
 cwt(Y::AbstractArray{T}, w::ContWaveClass; varargs...) where {T<:Number, S<:Real, V<:Real} = cwt(Y,CWT(w); varargs...)
 caveats(Y::AbstractArray{T}, w::ContWaveClass; J1::S=NaN) where {T<: Number, S<: Real} = caveats(Y,CWT(w),J1=J1)
 cwt(Y::AbstractArray{T}) where T<:Real = cwt(Y,Morlet())
@@ -285,13 +290,13 @@ struct PenroseDelta <: InverseType end
 Compute the inverse wavelet transform using one of three dual frames. The default uses delta functions with weights chosen via a least squares method, the `PenroseDelta()` below. This is chosen as a default because the Morlet wavelets tend to fail catastrophically using the canonical dual frame (the `dualFrames()` type).
 
     icwt(res::AbstractArray, cWav::CWT, inverseStyle::PenroseDelta)
-return the inverse continuous wavelet transform, computed using the simple dual frame ``β_jδ_{ji}``, where ``β_j`` is chosen to solve the least squares problem ``\\|Ŵβ-1\\|_2^2``, where ``Ŵ`` is the Fourier domain representation of the `cWav` wavelets. In both this case and `NaiveDelta()`, the fourier transform of ``δ`` is the constant function, thus this least squares problem.
+Return the inverse continuous wavelet transform, computed using the simple dual frame ``β_jδ_{ji}``, where ``β_j`` is chosen to solve the least squares problem ``\\|Ŵβ-1\\|_2^2``, where ``Ŵ`` is the Fourier domain representation of the `cWav` wavelets. In both this case and `NaiveDelta()`, the fourier transform of ``δ`` is the constant function, thus this least squares problem.
 
     icwt(res::AbstractArray, cWav::CWT, inverseStyle::NaiveDelta)
-return the inverse continuous wavelet transform, computed using the simple dual frame ``β_jδ_{ji}``, where ``β_j`` is chosen to negate the scale factor ``(^1/_s)^{^1/_p}``. Generally less accurate than choosing the weights using `PenroseDelta`. This is the method discussed in Torrence and Compo.
+Return the inverse continuous wavelet transform, computed using the simple dual frame ``β_jδ_{ji}``, where ``β_j`` is chosen to negate the scale factor ``(^1/_s)^{^1/_p}``. Generally less accurate than choosing the weights using `PenroseDelta`. This is the method discussed in Torrence and Compo.
 
     icwt(res::AbstractArray, cWav::CWT, inverseStyle::dualFrames)
-return the inverse continuous wavelet transform, computed using the canonical dual frame ``\\tilde{\\widehat{ψ}} = \\frac{ψ̂_n(ω)}{∑_n\\|ψ̂_n(ω)\\|^2}``. The algorithm is to compute the cwt again, but using the canonical dual frame; consiquentially, it is the most computationally intensive of the three algorithms, and typically the best behaved. Will be numerically unstable if the high frequencies of all of the wavelets are too small however, and tends to fail spectacularly in this case.
+Return the inverse continuous wavelet transform, computed using the canonical dual frame ``\\tilde{\\widehat{ψ}} = \\frac{ψ̂_n(ω)}{∑_n\\|ψ̂_n(ω)\\|^2}``. The algorithm is to compute the cwt again, but using the canonical dual frame; consiquentially, it is the most computationally intensive of the three algorithms, and typically the best behaved. Will be numerically unstable if the high frequencies of all of the wavelets are too small however, and tends to fail spectacularly in this case.
 
 """
 function icwt(res::AbstractArray, cWav::CWT, inverseStyle::PenroseDelta)

--- a/src/createWavelets.jl
+++ b/src/createWavelets.jl
@@ -27,10 +27,10 @@ end
 
 
 """
-    daughter = mother(this::CWT{W, T, <:ContWaveClass, N},
-                        s::Real, nInOctave::Int, ω::AbstractArray{<:Real,1}) where {W, T, N}
+    mother(this::CWT{W, T, <:ContWaveClass, N}, s::Real, nInOctave::Int,
+        ω::AbstractArray{<:Real,1}) where {W, T, N} -> daughter
 
-given a CWT object, return a rescaled version of the mother wavelet, in the
+Given a CWT object, return a rescaled version of the mother wavelet, in the
 fourier domain. ω is the frequency, which is fftshift-ed. s is the scale
 variable.
 """
@@ -65,35 +65,35 @@ end
 function mother(this::CWT{W,T,Morse,N}, s::Real, sWidth::Real,
                   ω::AbstractArray{<:Real,1}) where {W,T,N}
     
-    ga = this.waveType.ga;
-    be = this.waveType.be;
-    cf = this.waveType.cf;
-    p = this.p;
+    ga = this.waveType.ga
+    be = this.waveType.be
+    cf = this.waveType.cf
+    p = this.p
 
-    fo = morsefreq(this);
-    fact = cf/fo;
+    fo = morsefreq(this)
+    fact = cf/fo
     
     #  ω = LinRange(0,1-(1/len),len)
-    # om = 2 * pi * ω./ fact / max(1, s);
-    #om = 2 * pi * (ω / s)./ fact;
-    # om = (ω / s) / cf;
-    # om = (ω / s) / fact;
+    # om = 2 * pi * ω./ fact / max(1, s)
+    #om = 2 * pi * (ω / s)./ fact
+    # om = (ω / s) / cf
+    # om = (ω / s) / fact
 
-    om = (ω / s);
+    om = ω / s
 
     if be == 0
-        daughter = 2 * exp.(-om.^ga);
+        daughter = @. 2 * exp(-om^ga)
     else
-        daughter = 2 * exp.(-be.*log.(fo) .+ fo.^ga .+ be.*log.(om) .- om.^ga);
+        daughter = @. 2 * exp(-be*log(fo) + fo^ga + be*log(om) - om^ga)
     end
     
-    daughter[1] = 1/2*daughter[1]; # Due to unit step function
+    daughter[1] = 1/2*daughter[1] # Due to unit step function
     # Ensure nice lowpass filters for beta=0;
     # Otherwise, doesn't matter since wavelets vanishes at zero frequency
 
     if any(daughter .!= daughter)
         @warn "the given values of gamma and beta are numerically unstable"
-        daughter[daughter .!= daughter] .= 0;
+        daughter[daughter .!= daughter] .= 0
     end
     
     return ContinuousWavelets.normalize(daughter, s, p)
@@ -106,8 +106,9 @@ function mother(this::CWT{W,T,<:ContOrtho,N}, s::Real, itpψ,
     daughter = circshift(daughter, -round(Int, n1 / s / 2))
     return daughter
 end
+
 function normalize(daughter, s, p)
-    if p == Inf
+    if isinf(p)
         normTerm = maximum(abs.(daughter))
     else
         normTerm = s^(1 / p)
@@ -118,8 +119,8 @@ end
 """
     father(c::CWT, ω, averagingType::aT) where {aT<:Averaging}
 
-this creates the averaging function, which covers the low frequency
-information, and is emphatically not analytic. aT determines whether it has the
+This creates the averaging function, which covers the low frequency
+information, and is emphatically not analytic. `aT` determines whether it has the
 same form as the wavelets (`Father`), or just a bandpass `Dirac`.
 `c.averagingLength` gives the number of octaves (base 2) that are covered by
 the averaging function. The width is then derived so that it matches the next
@@ -133,7 +134,7 @@ For the Paul wavelets, it's a easy calculation to see that the mean of a paul
 wavelet of order m is (m+1)/s, while σ=sqrt(m+1)/s. So we set the variance so
 that the averaging function has 1σ at the central frequency of the last scale.
 
-the derivative of a Gaussian (Dog) has a pretty nasty form for the mean and
+The derivative of a Gaussian (Dog) has a pretty nasty form for the mean and
 variance; eventually, if you set 1/2 * σ_{averaging}=⟨ω⟩_{highest scale wavelet}, you
 will get the scale of the averaging function to be
 `s*gamma((c.α+2)/2)/sqrt(gamma((c.α+1)/2)*(gamma((c.α+3)/2)-gamma((c.α+2)/2)))`
@@ -180,9 +181,9 @@ end
 
 
 @doc """
-      (daughters, ω) = computeWavelets(n1::Integer, c::CWT{W}; T=Float64, J1::Int64=-1, dt::S=NaN, s0::V=NaN) where {S<:Real,
-                                                                   W<:WaveletBoundary, V}
-just precomputes the wavelets used by transform c::CWT{W}. For details, see cwt
+    computeWavelets(n1::Integer, c::CWT{W}; T=Float64, J1::Int64=-1, dt::S=NaN, s0::V=NaN)
+        where {S<:Real, W<:WaveletBoundary, V} -> daughters, ω
+Precomputes the wavelets used by transform c::CWT{W}. For details, see cwt.
 """
 function computeWavelets(n1::Integer, c::CWT{B,CT,W}; T=Float64, J1::Int64=-1, dt::S=NaN, s0::V=NaN, space=false) where {S <: Real,B <: WaveletBoundary,V,W,CT}
     # don't alter scaling with sampling information if it doesn't exists

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -28,13 +28,12 @@ function morsefreq(c::CWT{W,T,Morse,N}) where {W,T,N}
 end
 
 
-
 """
-    nOctaves, totalWavelets, sRanges, sWidth = getNWavelets(n1,c)
+    getNWavelets(n1,c) -> nOctaves, totalWavelets, sRanges, sWidth
 
-utility for understanding the spacing of the wavelets. `sRanges` is a list of
-the s values used in each octave. sWidth is a list of the corresponding
-variance adjustments
+Utility for understanding the spacing of the wavelets. `sRanges` is a list of
+the s values used in each octave. `sWidth`` is a list of the corresponding
+variance adjustments.
 """
 function getNWavelets(n1, c::CWT)
     nOctaves = getNOctaves(n1, c)

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -53,10 +53,8 @@ function getNWavelets(n1, c::CWT)
 end
 
 
-
-
 """
-different wavelet familes need to end at a different number of octaves because they have different tail behavior
+Different wavelet familes need to end at a different number of octaves because they have different tail behavior.
 """
 getNOctaves(n1,c::CWT{W,T, M, N}) where {W, T, N, M} = log2(n1>>1+1) + c.extraOctaves
 # choose the number of octaves so the last mean, which is at s*σ[1]
@@ -156,10 +154,7 @@ function genSamplePoints(nOct, c)
     firstWavelet, lastWavelet, stepSize
 end
 
-"""
-
-adjust the length of the storage based on the boundary conditions
-"""
+"Adjust the length of the storage based on the boundary conditions."
 function setn(n1, c)
     if boundaryType(c) <: ZPBoundary
         base2 = ceil(Int,log2(n1));   # power of 2 nearest to n1
@@ -178,10 +173,6 @@ function setn(n1, c)
     end
     return n, nSpace
 end
-
-
-
-
 
 
 # computing averaging function utils
@@ -213,10 +204,9 @@ function locationShift(c::CWT{W, T, <:Morse, N}, s, ω, sWidth) where {W,T,N}
     return (s0, ω_shift)
 end
 
-"""
-get the mean of the mother wavelet where s=1
-"""
-function getMean(c::CWT{W, T, <:Dog},s=1) where {W,T}
+
+"Get the mean of the mother wavelet where s=1."
+function getMean(c::CWT{W, T, <:Dog}, s=1) where {W,T}
     Gm1 = gamma((c.α+1)/2)
     Gm2 = gamma((c.α+2)/2)
     Gm2 / Gm1 * sqrt(2) * s^2
@@ -229,9 +219,11 @@ function getMean(c::CWT{W, T, <:Morse},s=1) where {W,T}
     #return s*c.waveType.cf
     return s*morsefreq(c)
 end
+
 """
     getStd(c::CWT{W, T, <:Dog}, s=1) where {W,T}
-get the standard deviation of the mother wavelet
+
+Get the standard deviation of the mother wavelet.
 """
 getStd(c::CWT{W, T, <:Dog}, s=1) where {W,T} = sqrt(c.α + 1 - getMean(c)^2)*s^(3/2)
 getStd(c::CWT{W, T, <:Paul},s=1) where {W, T} = sqrt((c.α+2)*(c.α+1)) * s
@@ -259,7 +251,10 @@ end
 
 """
     arrayOfFreqs = getMeanFreq(Ŵ, δt=1000)
-Calculate each of the mean frequencies of a collection of analytic or real wavelets Ŵ. assumes a sampling rate of 2kHz, so the maximum frequency is 1kHz. Change δt to adjust to your problem.
+
+Calculate each of the mean frequencies of a collection of analytic or real wavelets Ŵ.
+This assumes a sampling rate of 2kHz, so the maximum frequency is 1kHz. Change δt to adjust
+to your problem.
 """
 function getMeanFreq(Ŵ, δt=2000)
     eachNorm = [norm(w,1) for w in eachslice(Ŵ,dims=ndims(Ŵ))]'
@@ -283,8 +278,9 @@ function getContWaveFromOrtho(c,N)
 end
 
 """
-    nIters, sigLength = calcDepth(w,N)
-given a `CWT` with an orthogonal wavelet type, calculate the depth `nIters`
+    calcDepth(w,N) -> nIters, sigLength
+
+Given a `CWT` with an orthogonal wavelet type, calculate the depth `nIters`
 necessary to get a resulting wavelet longer than `N`. `sigLength` is the
 resulting length.
 """
@@ -324,8 +320,11 @@ genInterp(ψ) = interpolate(ψ, BSpline(Quadratic(Reflect(OnGrid()))))
 
 
 """
-    β = computeDualWeights(Ŵ)
-compute the weight given to each wavelet so that in the Fourier domain, the sum across wavelets is as close to 1 at every frequency below the peak of the last wavelet (that is `β' .*abs.(Ŵ[1:lastFreq,:]) ≈ ones(lastFreq)` in an ℓ^2 sense)
+    computeDualWeights(Ŵ) -> β
+
+Compute the weight given to each wavelet so that in the Fourier domain, the sum across
+wavelets is as close to 1 at every frequency below the peak of the last wavelet
+(that is `β' .*abs.(Ŵ[1:lastFreq,:]) ≈ ones(lastFreq)` in an ℓ^2 sense).
 """
 function computeDualWeights(Ŵ, wav)
     @views lastReasonableFreq = computeLastFreq(Ŵ[:,end], wav)
@@ -342,7 +341,11 @@ computeLastFreq(ŵ, wav::CWT{W,T,<:Morlet}) where {W,T} = findlast(abs.(ŵ) .>
 
 """
     computeNaiveDualWeights(Ŵ, wav, n1)
-Compute the dual weights using the scaling amounts and the normalization power p. Primarily used when the least squares version is poorly constructed. When the least squares version doesn't perform well, this is also likely to have poor reconstruction, but it won't give extremely negative or oscillatory weights like the least squares version.
+
+Compute the dual weights using the scaling amounts and the normalization power p. Primarily
+used when the least squares version is poorly constructed. When the least squares version
+doesn't perform well, this is also likely to have poor reconstruction, but it won't give
+extremely negative or oscillatory weights like the least squares version.
 """
 function computeNaiveDualWeights(Ŵ, wav, n1)
     _, _, sRange, _ = ContinuousWavelets.getNWavelets(n1, wav)
@@ -370,8 +373,9 @@ function computeNaiveDualWeights(Ŵ, wav, n1)
 end
 
 """
-    dualCover, dualNorm = getDualCoverage(n,cWav, invType)
-get the sum of the weights and its deviation from 1
+    getDualCoverage(n,cWav, invType) -> dualCover, dualNorm
+
+Get the sum of the weights and its deviation from 1.
 """
 function getDualCoverage(n,cWav, invType)
     Ŵ = computeWavelets(n,cWav)[1]
@@ -392,7 +396,10 @@ function dualDeviance(n, cWav, naive)
 end
 
 """
-Explicitly construct the canonical dual frame elements for a translation invariant frame. This is likely to end poorly due to the low representation at high frequencies.
+    explicitConstruction(Ŵ)
+
+Explicitly construct the canonical dual frame elements for a translation invariant frame.
+This is likely to end poorly due to the low representation at high frequencies.
 """
 function explicitConstruction(Ŵ)
     Ŵdual = conj.(Ŵ ./ [norm(ŵ)^2 for ŵ in eachslice(Ŵ,dims=1)])

--- a/src/waveletTypes.jl
+++ b/src/waveletTypes.jl
@@ -1,12 +1,12 @@
 struct Morlet <: ContWaveClass
-    σ::Float64 # \sigma is the time/space trade-off. as sigma->0, the spacial resolution increases; below 5, there is a danger of being non-analytic. Default is 5.8
+    σ::Float64 # σ is the time/space trade-off. as σ->0, the spacial resolution increases; below 5, there is a danger of being non-analytic. Default is 5.8
     κσ::Float64
     cσ::Float64
 end
 """
-    morl = Morlet(σ::T) where T<: Real
+    morl = Morlet(σ::T) where T <: Real
 
-    return the Morlet wavelet with first central frequency parameter σ, which controls the time-frequency trade-off. As σ goes to zero, all of the information becomes spatial. Default is `` 2π``, and it is recommended that you stay within 3-12. Above this range, the overlap between wavelets becomes impractically small. Below it, the mean subtraction term approaches the magnitude of the wavelet, so they become a sum of Gaussians rather than Gaussians.
+Return the Morlet wavelet with first central frequency parameter `σ`, which controls the time-frequency trade-off. As σ goes to zero, all of the information becomes spatial. Default is `2π`, and it is recommended that you stay within 3-12. Above this range, the overlap between wavelets becomes impractically small. Below it, the mean subtraction term approaches the magnitude of the wavelet, so they become a sum of Gaussians rather than Gaussians.
 """
 function Morlet(σ::T) where T <: Real
     κσ = exp(-σ^2 / 2)
@@ -25,9 +25,9 @@ struct Morse <: ContinuousWavelets.ContWaveClass
     cf::Float64
 end
 """
-    morse = Morse(ga::T,be::T,cf::T) where T<: Float64
+    morse = Morse(ga::T,be::T,cf::T) where T <: Float64
 
-    return the Morse wavelet with the central frequency parameter cf, gamma parameter ga and beta parameter be.
+Return the Morse wavelet with the central frequency parameter `cf`, gamma parameter `ga`` and beta parameter `be``.
 """
 function Morse_convert(ga::Real, be::Real, cf::Real) 
     ga, be, cf = Float64.(ga), Float64.(be), Float64.(cf)


### PR DESCRIPTION
This PR is mostly about syntaxes, so all the functionalities should keep unchanged.

When scanning through the codes, I clearly sensed the remaining MATLAB-styles in many parts. Hopefully this PR can improve on the readability of the source codes.

In `src/CWTConstruction.jl`, I removed the broadcast for `order` within `calculateProperties`.  All tests passed on my local laptop, but there is a chance that these changes are not covered by the current test suite.