### PR TITLE
Add missing io to print in show for CWT

### DIFF
--- a/src/CWTConstruction.jl
+++ b/src/CWTConstruction.jl
@@ -138,7 +138,7 @@ function waveletType(::CWT{B,T,W,N}) where {B,T,W,N}
 end
 
 function Base.show(io::IO, cf::CWT{W,S,WT,N}) where {W,S,WT,N}
-    print("CWT{$(cf.waveType), $(cf.averagingType), Q=$(cf.Q), β=$(cf.β)," *
+    print(io, "CWT{$(cf.waveType), $(cf.averagingType), Q=$(cf.Q), β=$(cf.β)," *
           "aveLen=$(cf.averagingLength), frame=" * "$(cf.frameBound), norm=$(cf.p), extraOctaves=$(cf.extraOctaves)}")
 end
 


### PR DESCRIPTION
Fixes double printing in the REPL and missing inline displaying in VSCode